### PR TITLE
Remove ngZone calls

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
-import { MyMICDS, Action } from '@mymicds/sdk';
+import { Action, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, ViewContainerRef, NgZone } from '@angular/core';
-import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
+import { Component, OnInit, ViewContainerRef } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { defaultTitleFunction } from './app.routing';
 import { filter, map, switchMap } from 'rxjs/operators';
@@ -35,7 +35,6 @@ export class AppComponent extends SubscriptionsComponent implements OnInit {
 		private route: ActivatedRoute,
 		private titleService: Title,
 		private viewContainerRef: ViewContainerRef,
-		private ngZone: NgZone,
 		private alertService: AlertService
 	) {
 		super();
@@ -76,29 +75,27 @@ export class AppComponent extends SubscriptionsComponent implements OnInit {
 		// Error handling for MyMICDS SDK
 		this.addSubscription(
 			this.mymicds.errors.subscribe(error => {
-				this.ngZone.run(() => {
-					if ([Action.LOGIN_EXPIRED, Action.NOT_LOGGED_IN, Action.UNAUTHORIZED].includes(error.action)) {
-						this.router.navigate(['/login']);
-					}
+				if ([Action.LOGIN_EXPIRED, Action.NOT_LOGGED_IN, Action.UNAUTHORIZED].includes(error.action)) {
+					this.router.navigate(['/login']);
+				}
 
-					switch (error.action) {
-						case Action.LOGIN_EXPIRED:
+				switch (error.action) {
+					case Action.LOGIN_EXPIRED:
 						this.alertService.addWarning('Login expired! Please log in again.');
 						break;
 
-						case Action.NOT_LOGGED_IN:
+					case Action.NOT_LOGGED_IN:
 						this.alertService.addWarning('You are not logged in! You must be logged in access to this.');
 						break;
 
-						case Action.UNAUTHORIZED:
+					case Action.UNAUTHORIZED:
 						this.alertService.addWarning('Not so fast! You don\'t have access to this.');
 						break;
 
-						default:
+					default:
 						this.alertService.addError(error.message);
 						break;
-					}
-				});
+				}
 			})
 		);
 

--- a/src/app/common/auth.guard.ts
+++ b/src/app/common/auth.guard.ts
@@ -1,13 +1,13 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Injectable, NgZone } from'@angular/core';
+import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { AlertService } from '../services/alert.service';
 
 @Injectable()
 export class AuthGuard {
 
-	constructor(private mymicds: MyMICDS, private router: Router, private ngZone: NgZone, private alertService: AlertService) { }
+	constructor(private mymicds: MyMICDS, private router: Router, private alertService: AlertService) { }
 
 	canActivate() {
 		if (this.mymicds.auth.isLoggedIn) {
@@ -15,9 +15,7 @@ export class AuthGuard {
 		}
 
 		// If not logged in, redirect to login page
-		this.ngZone.run(() => {
-			this.router.navigate(['/login']);
-		});
+		this.router.navigate(['/login']);
 		this.alertService.addWarning('You are not logged in! You don\'t have access to this page.');
 		return false;
 	}

--- a/src/app/components/about/about.component.ts
+++ b/src/app/components/about/about.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import * as moment from 'moment';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
@@ -133,17 +133,15 @@ export class AboutComponent extends SubscriptionsComponent implements OnInit {
 
 	viewingVisits = false;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
 	ngOnInit() {
 		this.addSubscription(
 			this.mymicds.user.getGradeRange().subscribe(data => {
-				this.ngZone.run(() => {
-					this.gradeRange = data.gradYears;
-					this.getStats();
-				});
+				this.gradeRange = data.gradYears;
+				this.getStats();
 			})
 		);
 	}
@@ -151,106 +149,104 @@ export class AboutComponent extends SubscriptionsComponent implements OnInit {
 	getStats() {
 		this.addSubscription(
 			this.mymicds.stats.get().subscribe(data => {
-				this.ngZone.run(() => {
-					this.stats = data.stats;
+				this.stats = data.stats;
 
-					// Loop through grades to insert into line chart
-					for (let gradYear of Object.keys(this.stats.registered.gradYears)) {
-						// Keep track of total users at each point in time
-						let accountSum = 0;
-						this.lineData = [];
-						let dates = Object.keys(this.stats.registered.gradYears[gradYear]);
+				// Loop through grades to insert into line chart
+				for (let gradYear of Object.keys(this.stats.registered.gradYears)) {
+					// Keep track of total users at each point in time
+					let accountSum = 0;
+					this.lineData = [];
+					let dates = Object.keys(this.stats.registered.gradYears[gradYear]);
 
-						// Sort the dates people registered at
-						let mappedDates = dates.map(function(date, i) {
-							return {
-								index: i,
-								value: new Date(date).valueOf()
-							};
-						});
-						mappedDates.sort((a, b) => {
-							return a.value - b.value;
-						});
-						let sortedDates = mappedDates.map(function(el) {
-							return dates[el.index];
-						});
-
-						// Loop through sorted dates and add up total accounts
-						for (let i = 0 ; i < sortedDates.length; i++) {
-							let accountNumber = this.stats.registered.gradYears[gradYear][sortedDates[i]];
-							accountSum += accountNumber;
-							let registerCountDate = moment(sortedDates[i]);
-							this.lineData.push({x: registerCountDate, y: accountSum});
-						}
-
-						let gradeString = this.gradYearToGradeString(gradYear);
-
-						// Push data to line chart
-						this.lineDataSets.push({
-							label: gradeString,
-							data: this.lineData,
-							fill: false,
-							backgroundColor: prisma(gradeString).hex,
-							borderColor: prisma(gradeString).hex,
-							pointHoverBackgroundColor: '#fff',
-							pointHoverRadius: 5,
-							pointHoverBorderWidth: 2,
-							pointHitRadius: 10,
-						});
-					}
-
-					// Process data for pie chart
-					for (let gradYear of Object.keys(this.stats.visitedToday.gradYears)) {
-						this.pieData.push(this.stats.visitedToday.gradYears[gradYear]);
-						let gradeString = this.gradYearToGradeString(gradYear);
-						this.gradeNames.push(gradeString);
-						this.pieBgColors.push(prisma(gradeString).hex);
-					}
-
-					// Push data to pie chart
-					this.pieDataSets.push({
-						backgroundColor: this.pieBgColors,
-						data: this.pieData,
-						borderWidth: 0
+					// Sort the dates people registered at
+					let mappedDates = dates.map(function(date, i) {
+						return {
+							index: i,
+							value: new Date(date).valueOf()
+						};
+					});
+					mappedDates.sort((a, b) => {
+						return a.value - b.value;
+					});
+					let sortedDates = mappedDates.map(function(el) {
+						return dates[el.index];
 					});
 
-					// Initialize Charts
-					setTimeout(() => {
-						// Initialize Line Chart
-						this.lineCtx = document.getElementById('registerCountChart');
-						this.lineChart = new Chart(this.lineCtx, {
-							type: 'line',
-							data: {
-								datasets: this.lineDataSets
-							},
-							options: {
-								scales: {
-									xAxes: [{
-										type: 'time',
-										time: {
-											displayFormats: {
-												quarter: 'MMM YYYY'
-											}
-										}
-									}]
-								}
-							}
-						});
+					// Loop through sorted dates and add up total accounts
+					for (let i = 0 ; i < sortedDates.length; i++) {
+						let accountNumber = this.stats.registered.gradYears[gradYear][sortedDates[i]];
+						accountSum += accountNumber;
+						let registerCountDate = moment(sortedDates[i]);
+						this.lineData.push({x: registerCountDate, y: accountSum});
+					}
 
-						// Initialize Pie Chart
-						this.pieCtx = document.getElementById('visitedTodayChart');
-						this.pieChart = new Chart(this.pieCtx, {
-							type: 'pie',
-							data: {
-								labels: this.gradeNames,
-								datasets: this.pieDataSets
-							},
-							options: {
-								aspectRatio: 1
-							}
-						});
-					}, 1);
+					let gradeString = this.gradYearToGradeString(gradYear);
+
+					// Push data to line chart
+					this.lineDataSets.push({
+						label: gradeString,
+						data: this.lineData,
+						fill: false,
+						backgroundColor: prisma(gradeString).hex,
+						borderColor: prisma(gradeString).hex,
+						pointHoverBackgroundColor: '#fff',
+						pointHoverRadius: 5,
+						pointHoverBorderWidth: 2,
+						pointHitRadius: 10,
+					});
+				}
+
+				// Process data for pie chart
+				for (let gradYear of Object.keys(this.stats.visitedToday.gradYears)) {
+					this.pieData.push(this.stats.visitedToday.gradYears[gradYear]);
+					let gradeString = this.gradYearToGradeString(gradYear);
+					this.gradeNames.push(gradeString);
+					this.pieBgColors.push(prisma(gradeString).hex);
+				}
+
+				// Push data to pie chart
+				this.pieDataSets.push({
+					backgroundColor: this.pieBgColors,
+					data: this.pieData,
+					borderWidth: 0
 				});
+
+				// Initialize Charts
+				setTimeout(() => {
+					// Initialize Line Chart
+					this.lineCtx = document.getElementById('registerCountChart');
+					this.lineChart = new Chart(this.lineCtx, {
+						type: 'line',
+						data: {
+							datasets: this.lineDataSets
+						},
+						options: {
+							scales: {
+								xAxes: [{
+									type: 'time',
+									time: {
+										displayFormats: {
+											quarter: 'MMM YYYY'
+										}
+									}
+								}]
+							}
+						}
+					});
+
+					// Initialize Pie Chart
+					this.pieCtx = document.getElementById('visitedTodayChart');
+					this.pieChart = new Chart(this.pieCtx, {
+						type: 'pie',
+						data: {
+							labels: this.gradeNames,
+							datasets: this.pieDataSets
+						},
+						options: {
+							aspectRatio: 1
+						}
+					});
+				}, 1);
 			})
 		);
 	}

--- a/src/app/components/bulletin-archives/bulletin-archives.component.ts
+++ b/src/app/components/bulletin-archives/bulletin-archives.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import * as moment from 'moment';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
@@ -16,23 +16,21 @@ export class BulletinArchivesComponent extends SubscriptionsComponent implements
 	bulletinDateDisplays: string[] = [];
 	baseURL: string;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
 	ngOnInit() {
 		this.addSubscription(
 			this.mymicds.dailyBulletin.getList().subscribe(data => {
-				this.ngZone.run(() => {
-					this.bulletins = data.bulletins;
-					this.baseURL = data.baseURL;
+				this.bulletins = data.bulletins;
+				this.baseURL = data.baseURL;
 
-					// Loop through all the bulletins to get the display date
-					for (let i = 0; i < this.bulletins.length; i++) {
-						let date = moment(this.bulletins[i]);
-						this.bulletinDateDisplays[i] = date.format('dddd, MMMM Do, YYYY');
-					}
-				});
+				// Loop through all the bulletins to get the display date
+				for (let i = 0; i < this.bulletins.length; i++) {
+					let date = moment(this.bulletins[i]);
+					this.bulletinDateDisplays[i] = date.format('dddd, MMMM Do, YYYY');
+				}
 			})
 		);
 	}

--- a/src/app/components/confirm/confirm.component.ts
+++ b/src/app/components/confirm/confirm.component.ts
@@ -1,7 +1,7 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { typeOf } from '../../common/utils';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
@@ -22,7 +22,6 @@ export class ConfirmComponent extends SubscriptionsComponent implements OnInit {
 		private mymicds: MyMICDS,
 		private router: Router,
 		private route: ActivatedRoute,
-		private ngZone: NgZone,
 		private alertService: AlertService) {
 		super();
 	}
@@ -44,14 +43,10 @@ export class ConfirmComponent extends SubscriptionsComponent implements OnInit {
 					this.addSubscription(
 						this.mymicds.auth.confirm({ user, hash }, true).subscribe(
 							() => {
-								this.ngZone.run(() => {
-									this.confirmResponse = true;
-								});
+								this.confirmResponse = true;
 							},
 							() => {
-								this.ngZone.run(() => {
-									this.confirmResponse = 'Invalid confirmation link!';
-								});
+								this.confirmResponse = 'Invalid confirmation link!';
 							}
 						)
 					);

--- a/src/app/components/daily-bulletin/daily-bulletin.component.ts
+++ b/src/app/components/daily-bulletin/daily-bulletin.component.ts
@@ -1,7 +1,7 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import * as moment from 'moment';
 import { contains } from '../../common/utils';
 
@@ -25,7 +25,7 @@ export class DailyBulletinComponent extends SubscriptionsComponent implements On
 	parse = false;
 	parsedBulletin: any;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone, private router: Router, private route: ActivatedRoute) {
+	constructor(private mymicds: MyMICDS, private router: Router, private route: ActivatedRoute) {
 		super();
 	}
 
@@ -34,24 +34,22 @@ export class DailyBulletinComponent extends SubscriptionsComponent implements On
 
 		this.addSubscription(
 			this.mymicds.dailyBulletin.getList().subscribe(bulletinsData => {
-				this.ngZone.run(() => {
-					this.loading = false;
-					this.bulletinBaseURL = bulletinsData.baseURL;
-					this.bulletins = bulletinsData.bulletins;
+				this.loading = false;
+				this.bulletinBaseURL = bulletinsData.baseURL;
+				this.bulletins = bulletinsData.bulletins;
 
-					// Check if a specific bulletin was supplied in the url. By default use most recent bulletin.
-					const params = this.route.snapshot.params;
-					if (params.bulletin && contains(this.bulletins, params.bulletin)) {
-						this.bulletinIndex = this.bulletins.indexOf(params.bulletin);
-					}
+				// Check if a specific bulletin was supplied in the url. By default use most recent bulletin.
+				const params = this.route.snapshot.params;
+				if (params.bulletin && contains(this.bulletins, params.bulletin)) {
+					this.bulletinIndex = this.bulletins.indexOf(params.bulletin);
+				}
 
-					this.setBulletin(this.bulletinIndex, !params.bulletin);
+				this.setBulletin(this.bulletinIndex, !params.bulletin);
 
-					// Possibly parse
-					if (this.parse) {
-						this.getParsedBulletin();
-					}
-				});
+				// Possibly parse
+				if (this.parse) {
+					this.getParsedBulletin();
+				}
 			})
 		);
 	}

--- a/src/app/components/forgot-password/forgot-password.component.ts
+++ b/src/app/components/forgot-password/forgot-password.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { isAlphabetic, typeOf } from '../../common/utils';
 
@@ -21,7 +21,7 @@ export class ForgotPasswordComponent extends SubscriptionsComponent implements O
 	forgotResponse: boolean | string = null;
 	user: string;
 
-	constructor(private mymicds: MyMICDS, private router: Router, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS, private router: Router) {
 		super();
 	}
 
@@ -38,14 +38,10 @@ export class ForgotPasswordComponent extends SubscriptionsComponent implements O
 		this.addSubscription(
 			this.mymicds.auth.forgotPassword({ user: this.user }, true).subscribe(
 				() => {
-					this.ngZone.run(() => {
-						this.forgotResponse = true;
-					});
+					this.forgotResponse = true;
 				},
 				error => {
-					this.ngZone.run(() => {
-						this.forgotResponse = error.message;
-					});
+					this.forgotResponse = error.message;
 				}
 			)
 		);

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,7 +1,7 @@
 import { MyMICDS, MyMICDSModule, MyMICDSModuleType } from '@mymicds/sdk';
 
-import { Component, OnInit, ViewChild, ElementRef, ViewChildren, QueryList, AfterViewInit, NgZone } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { AfterViewInit, Component, ElementRef, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { GridsterComponent, GridsterItemComponent, IGridsterOptions } from 'angular2gridster';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 
@@ -77,7 +77,6 @@ export class HomeComponent extends SubscriptionsComponent implements OnInit, Aft
 		public mymicds: MyMICDS,
 		private router: Router,
 		private route: ActivatedRoute,
-		private ngZone: NgZone,
 		private alertService: AlertService
 	) {
 		super();
@@ -85,10 +84,8 @@ export class HomeComponent extends SubscriptionsComponent implements OnInit, Aft
 
 	ngOnInit() {
 		const onResize = () => {
-			this.ngZone.run(() => {
-				this.moduleWidth = this.moduleContainer.nativeElement.clientWidth;
-				this.moduleHeight = this.moduleContainer.nativeElement.clientHeight;
-			});
+			this.moduleWidth = this.moduleContainer.nativeElement.clientWidth;
+			this.moduleHeight = this.moduleContainer.nativeElement.clientHeight;
 		};
 		setTimeout(() => onResize());
 		this.resizeSensor = new ResizeSensor(this.moduleContainer.nativeElement, onResize);
@@ -106,31 +103,29 @@ export class HomeComponent extends SubscriptionsComponent implements OnInit, Aft
 		// Check if user has set Portal and Canvas URL
 		this.addSubscription(
 			this.mymicds.user.$.subscribe(user => {
-				this.ngZone.run(() => {
-					if (!user) {
-						return;
-					}
+				if (!user) {
+					return;
+				}
 
-					const lacks = [];
+				const lacks = [];
 
-					if (!user.portalURLClasses || !user.portalURLCalendar) {
-						lacks.push('Portal');
-					}
-					if (!user.canvasURL) {
-						lacks.push('Canvas');
-					}
+				if (!user.portalURLClasses || !user.portalURLCalendar) {
+					lacks.push('Portal');
+				}
+				if (!user.canvasURL) {
+					lacks.push('Canvas');
+				}
 
-					// Engagement announcements
-					if (!this.announcement) {
-						if (user.migrateToVeracross) {
-							// tslint:disable-next-line:max-line-length
-							this.announcement = `Hey there! <strong>It appears you haven\'t migrated your schedule feed with the new Veracross portal!</strong> To get the most out of MyMICDS, go to the <a class="alert-link" href="/settings">Settings Page</a> and follow the directions under 'URL Settings'.</strong>`;
-						} else if (lacks.length > 0) {
-							// tslint:disable-next-line:max-line-length
-							this.announcement = `Hey there! <strong>It appears you haven\'t integrated your ${lacks.join(' or ')} ${lacks.length > 1 ? 'feeds' : 'feed'} to get the most out of MyMICDS.</strong> Go to the <a class="alert-link" href="/settings">Settings Page</a> and follow the directions under 'URL Settings'.`;
-						}
+				// Engagement announcements
+				if (!this.announcement) {
+					if (user.migrateToVeracross) {
+						// tslint:disable-next-line:max-line-length
+						this.announcement = `Hey there! <strong>It appears you haven\'t migrated your schedule feed with the new Veracross portal!</strong> To get the most out of MyMICDS, go to the <a class="alert-link" href="/settings">Settings Page</a> and follow the directions under 'URL Settings'.</strong>`;
+					} else if (lacks.length > 0) {
+						// tslint:disable-next-line:max-line-length
+						this.announcement = `Hey there! <strong>It appears you haven\'t integrated your ${lacks.join(' or ')} ${lacks.length > 1 ? 'feeds' : 'feed'} to get the most out of MyMICDS.</strong> Go to the <a class="alert-link" href="/settings">Settings Page</a> and follow the directions under 'URL Settings'.`;
 					}
-				});
+				}
 			})
 		);
 
@@ -140,9 +135,7 @@ export class HomeComponent extends SubscriptionsComponent implements OnInit, Aft
 		// Get modules layout
 		this.addSubscription(
 			this.mymicds.modules.get().subscribe(({ modules }) => {
-				this.ngZone.run(() => {
-					this.updateModuleLayout(modules);
-				});
+				this.updateModuleLayout(modules);
 			})
 		);
 	}
@@ -190,16 +183,12 @@ export class HomeComponent extends SubscriptionsComponent implements OnInit, Aft
 		this.mymicds.modules.update({ modules: saveModules })
 			.subscribe(
 				({ modules }) => {
-					this.ngZone.run(() => {
-						this.savingModuleLayout = false;
-						this.updateModuleLayout(modules);
-						this.alertService.addSuccess('Successfully saved module layout!');
-					});
+					this.savingModuleLayout = false;
+					this.updateModuleLayout(modules);
+					this.alertService.addSuccess('Successfully saved module layout!');
 				},
 				() => {
-					this.ngZone.run(() => {
-						this.savingModuleLayout = false;
-					});
+					this.savingModuleLayout = false;
 				}
 			);
 	}

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { UAParser } from 'ua-parser-js';
 
@@ -20,7 +20,7 @@ export class LoginComponent extends SubscriptionsComponent implements OnInit {
 		remember: true,
 	};
 
-	constructor(private mymicds: MyMICDS, private router: Router, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private router: Router, private alertService: AlertService) {
 		super();
 	}
 
@@ -44,13 +44,11 @@ export class LoginComponent extends SubscriptionsComponent implements OnInit {
 				remember: this.loginModel.remember,
 				comment: jwtComment
 			}).subscribe(loginRes => {
-				this.ngZone.run(() => {
-					if (loginRes.success) {
-						this.router.navigate(['/home']);
-					} else {
-						this.alertService.addWarning(loginRes.message);
-					}
-				});
+				if (loginRes.success) {
+					this.router.navigate(['/home']);
+				} else {
+					this.alertService.addWarning(loginRes.message);
+				}
 			})
 		);
 	}

--- a/src/app/components/logout/logout.component.ts
+++ b/src/app/components/logout/logout.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
@@ -12,7 +12,7 @@ import { SubscriptionsComponent } from '../../common/subscriptions-component';
 })
 export class LogoutComponent extends SubscriptionsComponent implements OnInit {
 
-	constructor(private mymicds: MyMICDS, private router: Router, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS, private router: Router) {
 		super();
 	}
 
@@ -22,9 +22,7 @@ export class LogoutComponent extends SubscriptionsComponent implements OnInit {
 				() => {},
 				() => {},
 				() => {
-					this.ngZone.run(() => {
-						this.router.navigate(['/home']);
-					});
+					this.router.navigate(['/home']);
 				}
 			)
 		);

--- a/src/app/components/modules/countdown/countdown.component.ts
+++ b/src/app/components/modules/countdown/countdown.component.ts
@@ -1,7 +1,7 @@
-import { MyMICDS, GetPortalDayRotationResponse, GetBreaksResponse } from '@mymicds/sdk';
+import { GetBreaksResponse, GetPortalDayRotationResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, OnDestroy, Input, ElementRef, ViewChild, ViewChildren, QueryList, NgZone } from '@angular/core';
-import { trigger, state, style } from '@angular/animations';
+import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { state, style, trigger } from '@angular/animations';
 import { combineLatest } from 'rxjs';
 import { AngularFittextDirective } from 'angular-fittext';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
@@ -112,7 +112,7 @@ export class CountdownComponent extends SubscriptionsComponent implements OnInit
 
 	shaking: string;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -131,13 +131,11 @@ export class CountdownComponent extends SubscriptionsComponent implements OnInit
 				this.mymicds.dates.schoolEnds(),
 				this.mymicds.dates.getBreaks()
 			).subscribe(([days, schoolStarts, schoolEnds, breaks]) => {
-				this.ngZone.run(() => {
-					this.dayRotation = days.days;
-					this.schoolStarts = schoolStarts.date;
-					this.schoolEnds = schoolEnds.date;
-					this.breaks = breaks.breaks;
-					this.calculate();
-				});
+				this.dayRotation = days.days;
+				this.schoolStarts = schoolStarts.date;
+				this.schoolEnds = schoolEnds.date;
+				this.breaks = breaks.breaks;
+				this.calculate();
 			})
 		);
 	}

--- a/src/app/components/modules/progress/progress.component.ts
+++ b/src/app/components/modules/progress/progress.component.ts
@@ -1,25 +1,7 @@
-import {
-	MyMICDS,
-	GetScheduleResponse,
-	ScheduleBlock,
-	ClassType,
-	Block
-} from '@mymicds/sdk';
+import { Block, ClassType, GetScheduleResponse, MyMICDS, ScheduleBlock } from '@mymicds/sdk';
 
-import {
-	Component,
-	OnInit,
-	OnDestroy,
-	Input,
-	ViewChild,
-	ElementRef,
-	NgZone
-} from '@angular/core';
-import {
-	hexToRgb,
-	rainbowSafeWord,
-	rainbowCanvasGradient
-} from '../../../common/utils';
+import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { rainbowCanvasGradient, rainbowSafeWord } from '../../../common/utils';
 import * as moment from 'moment';
 import * as ElementQueries from 'css-element-queries/src/ElementQueries';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
@@ -78,7 +60,7 @@ export class ProgressComponent extends SubscriptionsComponent
 	// CanvasGradient object to use for rainbow color
 	rainbow: CanvasGradient;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -208,14 +190,12 @@ export class ProgressComponent extends SubscriptionsComponent
 					day: this.today.getDate()
 				})
 				.subscribe(({ schedule }) => {
-					this.ngZone.run(() => {
-						if (schedule) {
-							this.schedule = schedule;
-						} else {
-							this.schedule = null;
-						}
-						this.calculatePercentages();
-					});
+					if (schedule) {
+						this.schedule = schedule;
+					} else {
+						this.schedule = null;
+					}
+					this.calculatePercentages();
 				})
 		);
 	}

--- a/src/app/components/modules/schedule/schedule.component.ts
+++ b/src/app/components/modules/schedule/schedule.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetScheduleResponse } from '@mymicds/sdk';
+import { GetScheduleResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, OnDestroy, Input, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs/Rx';
 import { debounceTime } from 'rxjs/operators';
 import * as moment from 'moment';
@@ -48,7 +48,7 @@ export class ScheduleComponent extends SubscriptionsComponent implements OnInit,
 
 	changeSchedule$ = new Subject<void>();
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -102,17 +102,15 @@ export class ScheduleComponent extends SubscriptionsComponent implements OnInit,
 			month: date.month() + 1,
 			day  : date.date()
 		}).subscribe(({ schedule }) => {
-			this.ngZone.run(() => {
-				this.viewSchedule = schedule;
+			this.viewSchedule = schedule;
 
-				if (date.isSame(this.current, 'day')) {
-					this.currentSchedule = schedule;
-				}
+			if (date.isSame(this.current, 'day')) {
+				this.currentSchedule = schedule;
+			}
 
-				setTimeout(() => {
-					this.resizeTable();
-				}, 0);
-			});
+			setTimeout(() => {
+				this.resizeTable();
+			}, 0);
 		});
 	}
 

--- a/src/app/components/modules/simplified-lunch/simplified-lunch.component.ts
+++ b/src/app/components/modules/simplified-lunch/simplified-lunch.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS, School } from '@mymicds/sdk';
 
-import { Component, NgZone, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import * as moment from 'moment';
 import * as ElementQueries from 'css-element-queries/src/ElementQueries';
 
@@ -20,7 +20,7 @@ export class SimplifiedLunchComponent extends SubscriptionsComponent implements 
 	todaysLunch: DayLunch = null;
 	school: School = 'upperschool';
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private alertService: AlertService) {
 		super();
 	}
 
@@ -32,15 +32,13 @@ export class SimplifiedLunchComponent extends SubscriptionsComponent implements 
 
 		this.addSubscription(
 			this.mymicds.user.$.subscribe(data => {
-				this.ngZone.run(() => {
-					if (!data) {
-						if (data === null) {
-							this.alertService.addWarning('We couldn\'t determine your grade. Automatically selected Upper School lunch.');
-						}
-						return;
+				if (!data) {
+					if (data === null) {
+						this.alertService.addWarning('We couldn\'t determine your grade. Automatically selected Upper School lunch.');
 					}
-					this.school = data.school;
-				});
+					return;
+				}
+				this.school = data.school;
 			})
 		);
 	}
@@ -62,25 +60,23 @@ export class SimplifiedLunchComponent extends SubscriptionsComponent implements 
 				month: getDate.month() + 1,
 				day  : getDate.date()
 			}).subscribe(({ lunch }) => {
-				this.ngZone.run(() => {
-					// Stop loading
-					this.loading = false;
+				// Stop loading
+				this.loading = false;
 
-					if (dayOfWeek === 6 || dayOfWeek === 0) {
-						getDate.day(1);
-					}
-					let lunchIndex = getDate.format('YYYY[-]MM[-]DD');
-					let dayLunch = lunch[lunchIndex] || { };
+				if (dayOfWeek === 6 || dayOfWeek === 0) {
+					getDate.day(1);
+				}
+				let lunchIndex = getDate.format('YYYY[-]MM[-]DD');
+				let dayLunch = lunch[lunchIndex] || { };
 
-					this.todaysLunch = {
-						date: {
-							weekday: getDate.format('dddd'),
-							date: getDate.format('MMMM Do[,] YYYY'),
-							today: true
-						},
-						lunch: dayLunch
-					};
-				});
+				this.todaysLunch = {
+					date: {
+						weekday: getDate.format('dddd'),
+						date: getDate.format('MMMM Do[,] YYYY'),
+						today: true
+					},
+					lunch: dayLunch
+				};
 			})
 		);
 	}

--- a/src/app/components/modules/simplified-schedule/simplified-schedule.component.ts
+++ b/src/app/components/modules/simplified-schedule/simplified-schedule.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetScheduleResponse } from '@mymicds/sdk';
+import { GetScheduleResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, Input, OnInit, OnDestroy, ViewChild, ElementRef, ViewChildren, QueryList, NgZone } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import * as moment from 'moment';
 import * as ElementQueries from 'css-element-queries/src/ElementQueries';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
@@ -44,7 +44,7 @@ export class SimplifiedScheduleComponent extends SubscriptionsComponent implemen
 	schedule: GetScheduleResponse['schedule'] = null;
 	scheduleDate = moment();
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -57,10 +57,8 @@ export class SimplifiedScheduleComponent extends SubscriptionsComponent implemen
 				month: this.scheduleDate.month() + 1,
 				day  : this.scheduleDate.date()
 			}).subscribe(schedule => {
-				this.ngZone.run(() => {
-					this.schedule = schedule.schedule;
-					setTimeout(() => this.calcBlockDisplay());
-				});
+				this.schedule = schedule.schedule;
+				setTimeout(() => this.calcBlockDisplay());
 			})
 		);
 

--- a/src/app/components/modules/snowday/snowday.component.ts
+++ b/src/app/components/modules/snowday/snowday.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetSnowdayResponse } from '@mymicds/sdk';
+import { GetSnowdayResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import * as ElementQueries from 'css-element-queries/src/ElementQueries';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 
@@ -20,7 +20,7 @@ export class SnowdayComponent extends SubscriptionsComponent implements OnInit {
 
 	snowdayData: GetSnowdayResponse['data'] = null;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -35,9 +35,7 @@ export class SnowdayComponent extends SubscriptionsComponent implements OnInit {
 
 		this.addSubscription(
 			this.mymicds.snowday.get().subscribe(({ data }) => {
-				this.ngZone.run(() => {
-					this.snowdayData = data;
-				});
+				this.snowdayData = data;
 			})
 		);
 	}

--- a/src/app/components/modules/stickynotes/stickynotes.component.ts
+++ b/src/app/components/modules/stickynotes/stickynotes.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, Input, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs/Rx';
 import { debounceTime } from 'rxjs/operators';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
@@ -42,9 +42,7 @@ export class StickynotesComponent extends SubscriptionsComponent implements OnIn
 			this._moduleId = id;
 			this.addSubscription(
 				this.mymicds.stickyNotes.get({ moduleId: id }).subscribe(data => {
-					this.ngZone.run(() => {
-						this.text = data.text;
-					});
+					this.text = data.text;
 				})
 			);
 		}
@@ -63,7 +61,7 @@ export class StickynotesComponent extends SubscriptionsComponent implements OnIn
 	};
 	@Input() color;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 

--- a/src/app/components/modules/weather/weather.component.ts
+++ b/src/app/components/modules/weather/weather.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetWeatherResponse } from '@mymicds/sdk';
+import { GetWeatherResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, Input, OnInit, ElementRef, ViewChild, NgZone } from '@angular/core';
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import * as ElementQueries from 'css-element-queries/src/ElementQueries';
 
 import { SubscriptionsComponent } from '../../../common/subscriptions-component';
@@ -18,7 +18,7 @@ export class WeatherComponent extends SubscriptionsComponent implements OnInit {
 	@Input() metric = false;
 	@ViewChild('moduleContainer', { static: false }) containerEl: ElementRef;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -27,10 +27,8 @@ export class WeatherComponent extends SubscriptionsComponent implements OnInit {
 
 		this.addSubscription(
 			this.mymicds.weather.get().subscribe(({ weather }) => {
-				this.ngZone.run(() => {
-					this.weather = weather;
-					this.weatherMetric = this.convertToMetric(weather);
-				});
+				this.weather = weather;
+				this.weatherMetric = this.convertToMetric(weather);
 			})
 		);
 	}

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, JWT } from '@mymicds/sdk';
+import { JWT, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
@@ -49,7 +49,7 @@ export class NavbarComponent extends SubscriptionsComponent implements OnInit {
 		}
 	];
 
-	constructor(public mymicds: MyMICDS, private router: Router, private ngZone: NgZone) {
+	constructor(public mymicds: MyMICDS, private router: Router) {
 		super();
 	}
 
@@ -64,9 +64,7 @@ export class NavbarComponent extends SubscriptionsComponent implements OnInit {
 		// Keep track if user's auth state for login/logout buttons
 		this.addSubscription(
 			this.mymicds.auth.$.subscribe(jwt => {
-				this.ngZone.run(() => {
-					this.jwt = jwt;
-				});
+				this.jwt = jwt;
 			})
 		);
 	}

--- a/src/app/components/planner/planner.component.ts
+++ b/src/app/components/planner/planner.component.ts
@@ -1,12 +1,12 @@
-import { MyMICDS, MyMICDSClass, AddPlannerEventParameters, PlannerEvent, GetPortalDayRotationResponse } from '@mymicds/sdk';
+import { AddPlannerEventParameters, GetPortalDayRotationResponse, MyMICDS, MyMICDSClass, PlannerEvent } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import { Subject, fromEvent } from 'rxjs';
-import { tap, filter, map, switchMap } from 'rxjs/operators';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { fromEvent, Subject } from 'rxjs';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import * as moment from 'moment';
 import { BsDatepickerConfig } from 'ngx-bootstrap/datepicker';
-import { contains, darkenColor, rainbowSafeWord, rainbowCSSGradient } from '../../common/utils';
+import { contains, darkenColor, rainbowCSSGradient, rainbowSafeWord } from '../../common/utils';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
 import { AlertService } from '../../services/alert.service';
@@ -19,7 +19,7 @@ import { AlertService } from '../../services/alert.service';
 export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 
 	// We need to include this to use in HTML
-	public darkenColor = darkenColor; // tslint:disable-line
+	public darkenColor = darkenColor;
 
 	weekdays = [
 		'Sunday',
@@ -105,7 +105,6 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		public mymicds: MyMICDS,
 		private router: Router,
 		private route: ActivatedRoute,
-		private ngZone: NgZone,
 		private alertService: AlertService
 	) {
 		super();
@@ -132,9 +131,7 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		// Get day rotation
 		this.addSubscription(
 			this.mymicds.portal.getDayRotation().subscribe(({ days }) => {
-				this.ngZone.run(() => {
-					this.days = days;
-				});
+				this.days = days;
 			})
 		);
 
@@ -144,27 +141,21 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 			// Get list of classes for when user inserts their own event
 			this.addSubscription(
 				this.mymicds.classes.get().subscribe(({ classes }) => {
-					this.ngZone.run(() => {
-						this.classes = classes;
-					});
+					this.classes = classes;
 				})
 			);
 			// Get Canvas events
 			this.addSubscription(
 				this.mymicds.canvas.getEvents(true).subscribe(
 					data => {
-						this.ngZone.run(() => {
-							this.canvasLoading = false;
-							if (data.hasURL) {
-								this.canvasEvents = data.events;
-								this.updatePlannerEvents();
-							}
-						});
+						this.canvasLoading = false;
+						if (data.hasURL) {
+							this.canvasEvents = data.events;
+							this.updatePlannerEvents();
+						}
 					},
 					() => {
-						this.ngZone.run(() => {
-							this.canvasLoading = false;
-						});
+						this.canvasLoading = false;
 					}
 				)
 			);
@@ -177,20 +168,16 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 					switchMap(() => this.mymicds.canvas.getEvents())
 				).subscribe(
 					data => {
-						this.ngZone.run(() => {
-							this.canvasLoading = false
-							if (data.hasURL) {
-								this.canvasEvents = data.events;
-							} else {
-								this.canvasEvents = [];
-							}
-							this.updatePlannerEvents();
-						});
+						this.canvasLoading = false;
+						if (data.hasURL) {
+							this.canvasEvents = data.events;
+						} else {
+							this.canvasEvents = [];
+						}
+						this.updatePlannerEvents();
 					},
 					() => {
-						this.ngZone.run(() => {
-							this.canvasLoading = false;
-						});
+						this.canvasLoading = false;
 					}
 				)
 			);
@@ -223,15 +210,11 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		this.addSubscription(
 			this.mymicds.planner.getEvents(true).subscribe(
 				({ events }) => {
-					this.ngZone.run(() => {
-						this.plannerLoading = false;
-						this.updatePlannerEvents(events);
-					});
+					this.plannerLoading = false;
+					this.updatePlannerEvents(events);
 				},
 				() => {
-					this.ngZone.run(() => {
-						this.plannerLoading = false;
-					});
+					this.plannerLoading = false;
 				}
 			)
 		);
@@ -506,10 +489,8 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		this.addSubscription(
 			this.mymicds.planner.addEvent(this.formatEventData(this.createEventModel))
 				.subscribe(({ events }) => {
-					this.ngZone.run(() => {
-						this.alertService.addSuccess('Added event to planner!');
-						this.updatePlannerEvents(events);
-					});
+					this.alertService.addSuccess('Added event to planner!');
+					this.updatePlannerEvents(events);
 				})
 		);
 	}
@@ -561,10 +542,8 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		this.addSubscription(
 			this.mymicds.planner.addEvent(this.formatEventData(this.editEventModel))
 				.subscribe(({ events }) => {
-					this.ngZone.run(() => {
-						this.alertService.addSuccess('Edited event in planner!');
-						this.updatePlannerEvents(events);
-					});
+					this.alertService.addSuccess('Edited event in planner!');
+					this.updatePlannerEvents(events);
 				})
 		);
 	}
@@ -578,16 +557,14 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 		event.stopPropagation();
 		if (confirm('Are you sure you wanna delete this event from the planner?')) {
 			this.mymicds.planner.deleteEvent({ id }).subscribe(() => {
-				this.ngZone.run(() => {
-					this.alertService.addSuccess('Deleted event from planner!');
-					// Delete planner event from array
-					for (let i = 0; i < this.plannerEvents.length; i++) {
-						if (this.plannerEvents[i]._id === id) {
-							this.plannerEvents.splice(i--, 1);
-						}
+				this.alertService.addSuccess('Deleted event from planner!');
+				// Delete planner event from array
+				for (let i = 0; i < this.plannerEvents.length; i++) {
+					if (this.plannerEvents[i]._id === id) {
+						this.plannerEvents.splice(i--, 1);
 					}
-					this.updatePlannerEvents();
-				});
+				}
+				this.updatePlannerEvents();
 			})
 		}
 	}
@@ -628,8 +605,8 @@ export class PlannerComponent extends SubscriptionsComponent implements OnInit {
 				selectionEvents.item(i).scrollIntoView({ behavior: 'smooth' });
 				// shine the element
 				break;
-			};
-		};
+			}
+		}
 	}
 
 	// Close the side bar from a button

--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormBuilder, Validators } from '@angular/forms';
 import { confirmRegister } from '../../common/form-validation';
@@ -34,7 +34,7 @@ export class RegisterComponent extends SubscriptionsComponent implements OnInit 
 	submitted = false;
 	registerResponse: any = null;
 
-	constructor(private mymicds: MyMICDS, private router: Router, private formBuilder: FormBuilder, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS, private router: Router, private formBuilder: FormBuilder) {
 		super();
 	}
 
@@ -48,9 +48,7 @@ export class RegisterComponent extends SubscriptionsComponent implements OnInit 
 
 		this.addSubscription(
 			this.mymicds.user.getGradeRange().subscribe(data => {
-				this.ngZone.run(() => {
-					this.gradeRange = data.gradYears;
-				});
+				this.gradeRange = data.gradYears;
 			})
 		);
 	}
@@ -60,14 +58,10 @@ export class RegisterComponent extends SubscriptionsComponent implements OnInit 
 		this.addSubscription(
 			this.mymicds.auth.register(this.registerForm.value, true).subscribe(
 				() => {
-					this.ngZone.run(() => {
-						this.registerResponse = true;
-					});
+					this.registerResponse = true;
 				},
 				error => {
-					this.ngZone.run(() => {
-						this.registerResponse = error.message;
-					});
+					this.registerResponse = error.message;
 				}
 			)
 		);

--- a/src/app/components/reset-password/reset-password.component.ts
+++ b/src/app/components/reset-password/reset-password.component.ts
@@ -1,7 +1,7 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, Validators } from '@angular/forms';
 import { confirmPassword } from '../../common/form-validation';
 import { typeOf } from '../../common/utils';
@@ -33,8 +33,7 @@ export class ResetPasswordComponent extends SubscriptionsComponent implements On
 		private mymicds: MyMICDS,
 		private router: Router,
 		private formBuilder: FormBuilder,
-		private route: ActivatedRoute,
-		private ngZone: NgZone
+		private route: ActivatedRoute
 	) {
 		super();
 	}
@@ -49,15 +48,11 @@ export class ResetPasswordComponent extends SubscriptionsComponent implements On
 		this.addSubscription(
 			this.route.params.subscribe(
 				params => {
-					this.ngZone.run(() => {
-						this.user = params.user;
-						this.hash = params.hash;
-					});
+					this.user = params.user;
+					this.hash = params.hash;
 				},
 				() => {
-					this.ngZone.run(() => {
-						this.resetResponse = 'There was a problem getting the URL variables!';
-					});
+					this.resetResponse = 'There was a problem getting the URL variables!';
 				}
 			)
 		);
@@ -72,14 +67,10 @@ export class ResetPasswordComponent extends SubscriptionsComponent implements On
 				hash: this.hash
 			}).subscribe(
 				() => {
-					this.ngZone.run(() => {
-						this.resetResponse = true;
-					});
+					this.resetResponse = true;
 				},
 				error => {
-					this.ngZone.run(() => {
-						this.resetResponse = error.message;
-					});
+					this.resetResponse = error.message;
 				}
 			)
 		);

--- a/src/app/components/settings/aliases/aliases.component.ts
+++ b/src/app/components/settings/aliases/aliases.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, MyMICDSClass, ListAliasesResponse, AliasType } from '@mymicds/sdk';
+import { AliasType, ListAliasesResponse, MyMICDS, MyMICDSClass } from '@mymicds/sdk';
 
-import { Component, OnInit, Input, NgZone } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { contains } from '../../../common/utils';
 
 import { SubscriptionsComponent } from '../../../common/subscriptions-component';
@@ -24,7 +24,7 @@ export class AliasesComponent extends SubscriptionsComponent implements OnInit {
 
 	aliases: ListAliasesResponse['aliases'];
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private alertService: AlertService) {
 		super();
 	}
 
@@ -32,9 +32,7 @@ export class AliasesComponent extends SubscriptionsComponent implements OnInit {
 		// Get Aliases
 		this.addSubscription(
 			this.mymicds.alias.list().subscribe(({ aliases }) => {
-				this.ngZone.run(() => {
-					this.aliases = aliases;
-				});
+				this.aliases = aliases;
 			})
 		);
 	}
@@ -80,18 +78,16 @@ export class AliasesComponent extends SubscriptionsComponent implements OnInit {
 					classString: className,
 					classId: this.class._id
 				}).subscribe(({ id }) => {
-					this.ngZone.run(() => {
-						this.alertService.addSuccess(`Linked ${this.type} class from this MyMICDS class!`);
+					this.alertService.addSuccess(`Linked ${this.type} class from this MyMICDS class!`);
 
-						// Add alias to aliases array
-						this.aliases[this.type].push({
-							_id: id,
-							// User is not necessary
-							user: null,
-							type: this.type,
-							classNative: this.class._id,
-							classRemote: className
-						});
+					// Add alias to aliases array
+					this.aliases[this.type].push({
+						_id: id,
+						// User is not necessary
+						user: null,
+						type: this.type,
+						classNative: this.class._id,
+						classRemote: className
 					});
 				})
 			);
@@ -104,16 +100,14 @@ export class AliasesComponent extends SubscriptionsComponent implements OnInit {
 					type: this.type,
 					id: aliasId
 				}).subscribe(() => {
-					this.ngZone.run(() => {
-						this.alertService.addSuccess(`Unlinked ${this.type} class from this MyMICDS class!`);
+					this.alertService.addSuccess(`Unlinked ${this.type} class from this MyMICDS class!`);
 
-						// Remove alias from aliases array
-						for (let i = 0; i < this.aliases[this.type].length; i++) {
-							if (this.aliases[this.type][i]._id === aliasId) {
-								this.aliases[this.type].splice(i, 1);
-							}
+					// Remove alias from aliases array
+					for (let i = 0; i < this.aliases[this.type].length; i++) {
+						if (this.aliases[this.type][i]._id === aliasId) {
+							this.aliases[this.type].splice(i, 1);
 						}
-					});
+					}
 				})
 			);
 		}

--- a/src/app/components/settings/background/background.component.ts
+++ b/src/app/components/settings/background/background.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 import { SubscriptionsComponent } from '../../../common/subscriptions-component';
 import { AlertService } from '../../../services/alert.service';
@@ -22,7 +22,6 @@ export class BackgroundComponent extends SubscriptionsComponent implements OnIni
 
 	constructor(
 		private mymicds: MyMICDS,
-		private ngZone: NgZone,
 		private alertService: AlertService,
 		private backgroundService: BackgroundService
 	) {
@@ -32,9 +31,7 @@ export class BackgroundComponent extends SubscriptionsComponent implements OnIni
 	ngOnInit() {
 		this.addSubscription(
 			this.mymicds.background.$.subscribe(background => {
-				this.ngZone.run(() => {
-					this.hasDefaultBackground = background.hasDefault;
-				});
+				this.hasDefaultBackground = background.hasDefault;
 			})
 		);
 	}
@@ -62,21 +59,15 @@ export class BackgroundComponent extends SubscriptionsComponent implements OnIni
 		this.uploadingBackground = true;
 		this.mymicds.background.upload({ background: file }, true).subscribe(
 			() => {
-				this.ngZone.run(() => {
-					this.alertService.addSuccess('Uploaded background!');
-				});
+				this.alertService.addSuccess('Uploaded background!');
 			},
 			() => {
-				this.ngZone.run(() => {
-					this.uploadingBackground = false;
-				});
+				this.uploadingBackground = false;
 			},
 			() => {
-				this.ngZone.run(() => {
-					this.uploadingBackground = false;
-					this.fileSelected = false;
-					this.uploadForm.nativeElement.reset();
-				});
+				this.uploadingBackground = false;
+				this.fileSelected = false;
+				this.uploadForm.nativeElement.reset();
 			}
 		);
 	}

--- a/src/app/components/settings/classes/classes.component.ts
+++ b/src/app/components/settings/classes/classes.component.ts
@@ -1,6 +1,6 @@
 import { Block, ClassType, GetClassesResponse, MyMICDS, MyMICDSClass } from '@mymicds/sdk';
 
-import { Component, NgZone, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { combineLatest } from 'rxjs';
 import { defaultIfEmpty } from 'rxjs/operators';
 import { capitalize, contains } from '../../../common/utils';
@@ -67,7 +67,7 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 
 	aliasClass: MyMICDSClass = null;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private alertService: AlertService) {
 		super();
 	}
 
@@ -75,37 +75,31 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 		// Get list of user's classes
 		this.addSubscription(
 			this.mymicds.classes.get().subscribe(classes => {
-				this.ngZone.run(() => {
-					this.classesList = classes.classes;
-					// Stringify and parse classes so it is a seperate array
-					this.ogClasses = JSON.parse(JSON.stringify(this.classesList));
-				});
+				this.classesList = classes.classes;
+				// Stringify and parse classes so it is a seperate array
+				this.ogClasses = JSON.parse(JSON.stringify(this.classesList));
 			})
 		);
 
 		// Get Canvas classes
 		this.addSubscription(
 			this.mymicds.canvas.getClasses().subscribe(data => {
-				this.ngZone.run(() => {
-					if (data.hasURL) {
-						this.canvasClasses = data.classes;
-					} else {
-						this.canvasClasses = [];
-					}
-				});
+				if (data.hasURL) {
+					this.canvasClasses = data.classes;
+				} else {
+					this.canvasClasses = [];
+				}
 			})
 		);
 
 		// Get Canvas classes
 		this.addSubscription(
 			this.mymicds.portal.getClasses().subscribe(data => {
-				this.ngZone.run(() => {
-					if (data.hasURL) {
-						this.portalClasses = data.classes;
-					} else {
-						this.portalClasses = [];
-					}
-				});
+				if (data.hasURL) {
+					this.portalClasses = data.classes;
+				} else {
+					this.portalClasses = [];
+				}
 			})
 		);
 	}
@@ -119,7 +113,9 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 	// Detect if index of class experienced any changes
 	classChanged(id: string) {
 		// If class id is empty, then it's a new class and therefore cannot be changed
-		if (!id) { return true; }
+		if (!id) {
+			return true;
+		}
 
 		// Find class in class list
 		let currentClass = null;
@@ -129,7 +125,9 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 				break;
 			}
 		}
-		if (!currentClass) { return true; }
+		if (!currentClass) {
+			return true;
+		}
 
 		// Find original class
 		let ogClass = null;
@@ -139,7 +137,9 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 				break;
 			}
 		}
-		if (!ogClass) { return true; }
+		if (!ogClass) {
+			return true;
+		}
 
 		return currentClass.name !== ogClass.name
 			|| currentClass.color !== ogClass.color
@@ -202,7 +202,9 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 				break;
 			}
 		}
-		if (!ogClass) { return; }
+		if (!ogClass) {
+			return;
+		}
 
 		// Find class in class list
 		for (let scheduleClass of this.classesList) {
@@ -244,34 +246,30 @@ export class ClassesComponent extends SubscriptionsComponent implements OnInit {
 		let MEGAObservable$ = combineLatest([deleteClasses$, saveClasses$]);
 
 		MEGAObservable$.subscribe(([deleted, saved]) => {
-			this.ngZone.run(() => {
-				// Deleted class logic
-				if (deleted && deleted.length > 0) {
-					this.alertService.addSuccess(`Deleted ${deleted.length} classes.`);
-				}
+			// Deleted class logic
+			if (deleted && deleted.length > 0) {
+				this.alertService.addSuccess(`Deleted ${deleted.length} classes.`);
+			}
 
-				// Added class logic
-				if (saved && saved.length > 0) {
-					this.alertService.addSuccess(`Saved ${saved.length} classes.`);
+			// Added class logic
+			if (saved && saved.length > 0) {
+				this.alertService.addSuccess(`Saved ${saved.length} classes.`);
 
-					// Go through all classes without ids and insert their new ids
-					let idOffset = 0;
-					for (let currentClass of this.classesList) {
-						if (!currentClass._id) {
-							// Assign this new class the next id in the array
-							currentClass._id = saved[idOffset++].id;
-						}
+				// Go through all classes without ids and insert their new ids
+				let idOffset = 0;
+				for (let currentClass of this.classesList) {
+					if (!currentClass._id) {
+						// Assign this new class the next id in the array
+						currentClass._id = saved[idOffset++].id;
 					}
-
 				}
 
-				this.ogClasses = JSON.parse(JSON.stringify(this.classesList));
-				this.savingClasses = false;
-			});
+			}
+
+			this.ogClasses = JSON.parse(JSON.stringify(this.classesList));
+			this.savingClasses = false;
 		}, () => {
-			this.ngZone.run(() => {
-				this.savingClasses = false;
-			})
+			this.savingClasses = false;
 		});
 	}
 

--- a/src/app/components/settings/info/info.component.ts
+++ b/src/app/components/settings/info/info.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetUserInfoResponse, ChangeUserInfoParameters } from '@mymicds/sdk';
+import { ChangeUserInfoParameters, GetUserInfoResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, OnDestroy, NgZone } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 
 import { SubscriptionsComponent } from '../../../common/subscriptions-component';
@@ -26,7 +26,7 @@ export class InfoComponent extends SubscriptionsComponent implements OnInit, OnD
 
 	userInfo: GetUserInfoResponse = null;
 
-	constructor(private mymicds: MyMICDS, private formBuilder: FormBuilder, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private formBuilder: FormBuilder, private alertService: AlertService) {
 		super();
 	}
 
@@ -34,30 +34,26 @@ export class InfoComponent extends SubscriptionsComponent implements OnInit, OnD
 		// Get basic info
 		this.addSubscription(
 			this.mymicds.user.$.subscribe(data => {
-				this.ngZone.run(() => {
-					this.userInfo = data;
+				this.userInfo = data;
 
-					if (!this.userInfo) {
-						return;
-					}
+				if (!this.userInfo) {
+					return;
+				}
 
-					// Prefill user data in forms
-					this.infoForm = this.formBuilder.group({
-						firstName: [this.userInfo.firstName, Validators.required],
-						lastName: [this.userInfo.lastName, Validators.required],
-						gradYear: [this.userInfo.gradYear],
-						teacher: [this.userInfo.gradYear === null]
-					}, { validator: confirmGrade('gradYear', 'teacher') });
-				});
+				// Prefill user data in forms
+				this.infoForm = this.formBuilder.group({
+					firstName: [this.userInfo.firstName, Validators.required],
+					lastName: [this.userInfo.lastName, Validators.required],
+					gradYear: [this.userInfo.gradYear],
+					teacher: [this.userInfo.gradYear === null]
+				}, { validator: confirmGrade('gradYear', 'teacher') });
 			})
 		);
 
 		// Get graduation year range
 		this.addSubscription(
 			this.mymicds.user.getGradeRange().subscribe(gradeRange => {
-				this.ngZone.run(() => {
-					this.gradeRange = gradeRange.gradYears;
-				});
+				this.gradeRange = gradeRange.gradYears;
 			})
 		);
 	}

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -1,5 +1,5 @@
 import { MyMICDS } from '@mymicds/sdk';
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
 
 @Component({
@@ -12,16 +12,14 @@ export class SettingsComponent extends SubscriptionsComponent implements OnInit 
 	username: string = null;
 	authSubscription: any;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
 	ngOnInit() {
 		this.addSubscription(
 			this.authSubscription = this.mymicds.auth.$.subscribe(data => {
-				this.ngZone.run(() => {
-					this.username = data.user;
-				});
+				this.username = data.user;
 			})
 		);
 	}

--- a/src/app/components/settings/url/url.component.ts
+++ b/src/app/components/settings/url/url.component.ts
@@ -1,8 +1,8 @@
-import { MyMICDS, GetUserInfoResponse } from '@mymicds/sdk';
+import { GetUserInfoResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, AfterViewInit, NgZone } from '@angular/core';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { fromEvent } from 'rxjs';
-import { filter, switchMap, debounceTime } from 'rxjs/operators';
+import { debounceTime, filter, switchMap } from 'rxjs/operators';
 
 import { SubscriptionsComponent } from '../../../common/subscriptions-component';
 import { AlertService } from '../../../services/alert.service';
@@ -38,38 +38,36 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 
 	portalFeedUpdateLoading = false;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone, private alertService: AlertService) {
+	constructor(private mymicds: MyMICDS, private alertService: AlertService) {
 		super();
 	}
 
 	ngOnInit() {
 		this.addSubscription(
 			this.mymicds.user.$.subscribe(data => {
-				this.ngZone.run(() => {
-					this.userInfo = data;
+				this.userInfo = data;
 
-					if (!this.userInfo) {
-						return;
-					}
+				if (!this.userInfo) {
+					return;
+				}
 
-					// Get URL's
-					this.portalClassesURL = this.userInfo.portalURLClasses;
-					this.portalCalendarURL = this.userInfo.portalURLCalendar;
-					this.canvasURL = this.userInfo.canvasURL;
+				// Get URL's
+				this.portalClassesURL = this.userInfo.portalURLClasses;
+				this.portalCalendarURL = this.userInfo.portalURLCalendar;
+				this.canvasURL = this.userInfo.canvasURL;
 
-					if (this.portalClassesURL) {
-						this.portalClassesValid = true;
-						this.portalClassesResponse = 'Valid!';
-					}
-					if (this.portalCalendarURL) {
-						this.portalCalendarValid = true;
-						this.portalCalendarResponse = 'Valid!';
-					}
-					if (this.canvasURL) {
-						this.canvasValid = true;
-						this.canvasResponse = 'Valid!';
-					}
-				});
+				if (this.portalClassesURL) {
+					this.portalClassesValid = true;
+					this.portalClassesResponse = 'Valid!';
+				}
+				if (this.portalCalendarURL) {
+					this.portalCalendarValid = true;
+					this.portalCalendarResponse = 'Valid!';
+				}
+				if (this.canvasURL) {
+					this.canvasValid = true;
+					this.canvasResponse = 'Valid!';
+				}
 			})
 		);
 	}
@@ -94,7 +92,9 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 			const canvasInput = document.getElementById('canvas-url');
 
 			// Keep trying until DOM is loaded
-			if (!portalClassesInput || !portalCalendarInput || !canvasInput) { return; }
+			if (!portalClassesInput || !portalCalendarInput || !canvasInput) {
+				return;
+			}
 			clearInterval(interval);
 
 			// Subscribe to Portal and Canvas URL inputs to test URL
@@ -108,10 +108,8 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 						return this.mymicds.portal.testClassesURL({ url: this.portalClassesURL });
 					})
 				).subscribe(data => {
-					this.ngZone.run(() => {
-						this.portalClassesValid = (data.valid === true);
-						this.portalClassesResponse = (data.valid === true) ? 'Valid!' : data.valid;
-					});
+					this.portalClassesValid = (data.valid === true);
+					this.portalClassesResponse = (data.valid === true) ? 'Valid!' : data.valid;
 				})
 			);
 
@@ -125,10 +123,8 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 						return this.mymicds.portal.testCalendarURL({ url: this.portalCalendarURL });
 					}),
 				).subscribe(data => {
-					this.ngZone.run(() => {
-						this.portalCalendarValid = (data.valid === true);
-						this.portalCalendarResponse = (data.valid === true) ? 'Valid!' : data.valid;
-					});
+					this.portalCalendarValid = (data.valid === true);
+					this.portalCalendarResponse = (data.valid === true) ? 'Valid!' : data.valid;
 				})
 			);
 
@@ -142,10 +138,8 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 						return this.mymicds.canvas.testURL({ url: this.canvasURL });
 					})
 				).subscribe(data => {
-					this.ngZone.run(() => {
-						this.canvasValid = (data.valid === true);
-						this.canvasResponse = (data.valid === true) ? 'Valid!' : data.valid;
-					});
+					this.canvasValid = (data.valid === true);
+					this.canvasResponse = (data.valid === true) ? 'Valid!' : data.valid
 				})
 			);
 		}, 1);
@@ -159,19 +153,18 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 		this.portalClassesSaving = true;
 		this.mymicds.portal.setClassesURL({ url: this.portalClassesURL }, true).subscribe(
 			data => {
-				this.ngZone.run(() => {
-					this.portalClassesValid = (data.valid === true);
-					this.portalClassesResponse = (data.valid === true) ? 'Valid!' : data.valid;
-					if (data.valid === true) {
-						this.userInfo.portalURLClasses = data.url;
-						this.portalClassesURL = data.url;
-						this.alertService.addSuccess('Changed Portal Classes URL!');
-					} else {
-						this.alertService.addWarning(`Change Portal URL Warning: ${data.valid}`);
-					}
-				});
+				this.portalClassesValid = (data.valid === true);
+				this.portalClassesResponse = (data.valid === true) ? 'Valid!' : data.valid;
+				if (data.valid === true) {
+					this.userInfo.portalURLClasses = data.url;
+					this.portalClassesURL = data.url;
+					this.alertService.addSuccess('Changed Portal Classes URL!');
+				} else {
+					this.alertService.addWarning(`Change Portal URL Warning: ${data.valid}`);
+				}
 			},
-			() => {},
+			() => {
+			},
 			() => {
 				this.portalClassesSaving = false;
 			}
@@ -182,19 +175,18 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 		this.portalCalendarSaving = true;
 		this.mymicds.portal.setCalendarURL({ url: this.portalCalendarURL }, true).subscribe(
 			data => {
-				this.ngZone.run(() => {
-					this.portalCalendarValid = (data.valid === true);
-					this.portalCalendarResponse = (data.valid === true) ? 'Valid!' : data.valid;
-					if (data.valid === true) {
-						this.userInfo.portalURLCalendar = data.url;
-						this.portalCalendarURL = data.url;
-						this.alertService.addSuccess('Changed Portal Calendar URL!');
-					} else {
-						this.alertService.addWarning(`Change Portal URL Warning: ${data.valid}`);
-					}
-				});
+				this.portalCalendarValid = (data.valid === true);
+				this.portalCalendarResponse = (data.valid === true) ? 'Valid!' : data.valid;
+				if (data.valid === true) {
+					this.userInfo.portalURLCalendar = data.url;
+					this.portalCalendarURL = data.url;
+					this.alertService.addSuccess('Changed Portal Calendar URL!');
+				} else {
+					this.alertService.addWarning(`Change Portal URL Warning: ${data.valid}`);
+				}
 			},
-			() => {},
+			() => {
+			},
 			() => {
 				this.portalCalendarSaving = false;
 			}
@@ -205,19 +197,18 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 		this.canvasSaving = true;
 		this.mymicds.canvas.setURL({ url: this.canvasURL }, true).subscribe(
 			data => {
-				this.ngZone.run(() => {
-					this.canvasValid = (data.valid === true);
-					this.canvasResponse = (data.valid === true) ? 'Valid!' : data.valid as string;
-					if (data.valid === true) {
-						this.userInfo.canvasURL = data.url;
-						this.canvasURL = data.url;
-						this.alertService.addSuccess('Changed Canvas URL!');
-					} else {
-						this.alertService.addWarning(`Change Canvas URL Warning: ${data.valid}`);
-					}
-				});
+				this.canvasValid = (data.valid === true);
+				this.canvasResponse = (data.valid === true) ? 'Valid!' : data.valid as string;
+				if (data.valid === true) {
+					this.userInfo.canvasURL = data.url;
+					this.canvasURL = data.url;
+					this.alertService.addSuccess('Changed Canvas URL!');
+				} else {
+					this.alertService.addWarning(`Change Canvas URL Warning: ${data.valid}`);
+				}
 			},
-			() => {},
+			() => {
+			},
 			() => {
 				this.canvasSaving = false;
 			}
@@ -230,11 +221,10 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 			() => {
 				this.alertService.addSuccess('Updated canvas feed!');
 			},
-			() => {},
 			() => {
-				this.ngZone.run(() => {
-					this.canvasFeedUpdateLoading = false;
-				});
+			},
+			() => {
+				this.canvasFeedUpdateLoading = false;
 			}
 		);
 	}
@@ -245,11 +235,10 @@ export class UrlComponent extends SubscriptionsComponent implements OnInit, Afte
 			() => {
 				this.alertService.addSuccess('Updated portal feed!');
 			},
-			() => {},
 			() => {
-				this.ngZone.run(() => {
-					this.portalFeedUpdateLoading = false;
-				});
+			},
+			() => {
+				this.portalFeedUpdateLoading = false;
 			}
 		);
 	}

--- a/src/app/components/sports/sports.component.ts
+++ b/src/app/components/sports/sports.component.ts
@@ -1,6 +1,6 @@
-import { MyMICDS, GetScoresResponse } from '@mymicds/sdk';
+import { GetScoresResponse, MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { SubscriptionsComponent } from '../../common/subscriptions-component';
 
@@ -15,7 +15,7 @@ export class SportsComponent extends SubscriptionsComponent implements OnInit {
 	sportsScores: GetScoresResponse['scores']['scores'] = [];
 	loadingScores: boolean;
 
-	constructor(private mymicds: MyMICDS, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS) {
 		super();
 	}
 
@@ -23,12 +23,10 @@ export class SportsComponent extends SubscriptionsComponent implements OnInit {
 		this.loadingScores = true;
 		this.addSubscription(
 			this.mymicds.sports.getScores().subscribe(({ scores }) => {
-				this.ngZone.run(() => {
-					this.sportsEvents = scores.events;
-					this.sportsScores = scores.scores;
-					console.log(scores.scores);
-					this.loadingScores = false;
-				});
+				this.sportsEvents = scores.events;
+				this.sportsScores = scores.scores;
+				console.log(scores.scores);
+				this.loadingScores = false
 			})
 		);
 	}

--- a/src/app/components/suggestions/suggestions.component.ts
+++ b/src/app/components/suggestions/suggestions.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { typeOf } from '../../common/utils';
 
@@ -22,7 +22,7 @@ export class SuggestionsComponent extends SubscriptionsComponent implements OnIn
 
 	suggestionsForm: FormGroup;
 
-	constructor(private mymicds: MyMICDS, private fb: FormBuilder, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS, private fb: FormBuilder) {
 		super();
 	}
 
@@ -38,14 +38,10 @@ export class SuggestionsComponent extends SubscriptionsComponent implements OnIn
 		this.addSubscription(
 			this.mymicds.suggestion.submit(this.suggestionsForm.value, true).subscribe(
 				() => {
-					this.ngZone.run(() => {
-						this.suggestionResponse = true;
-					});
+					this.suggestionResponse = true;
 				},
 				err => {
-					this.ngZone.run(() => {
-						this.suggestionResponse = err;
-					});
+					this.suggestionResponse = err;
 				}
 			)
 		);

--- a/src/app/components/unsubscribe/unsubscribe.component.ts
+++ b/src/app/components/unsubscribe/unsubscribe.component.ts
@@ -1,6 +1,6 @@
 import { MyMICDS } from '@mymicds/sdk';
 
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest } from 'rxjs';
 import { typeOf } from '../../common/utils';
@@ -18,7 +18,7 @@ export class UnsubscribeComponent extends SubscriptionsComponent implements OnIn
 	typeOf = typeOf;
 	unsubscribeResponse: boolean = null;
 
-	constructor(private mymicds: MyMICDS, private route: ActivatedRoute, private ngZone: NgZone) {
+	constructor(private mymicds: MyMICDS, private route: ActivatedRoute) {
 		super();
 	}
 
@@ -35,22 +35,16 @@ export class UnsubscribeComponent extends SubscriptionsComponent implements OnIn
 					this.addSubscription(
 						this.mymicds.notifications.unsubscribe({ user, hash, type }, true).subscribe(
 							() => {
-								this.ngZone.run(() => {
-									this.unsubscribeResponse = true;
-								});
+								this.unsubscribeResponse = true;
 							},
 							() => {
-								this.ngZone.run(() => {
-									this.unsubscribeResponse = false;
-								});
+								this.unsubscribeResponse = false;
 							}
 						)
 					);
 				},
 				() => {
-					this.ngZone.run(() => {
-						this.unsubscribeResponse = false;
-					});
+					this.unsubscribeResponse = false;
 				}
 			)
 		);


### PR DESCRIPTION
This PR removes all the (as of now) unnecessary calls to `this.ngZone` inside of SDK observables. Resolves #94.