### PR TITLE
Add more responsive padding on day event list

### DIFF
--- a/src/app/components/planner/planner.component.html
+++ b/src/app/components/planner/planner.component.html
@@ -80,9 +80,9 @@
 
 			<div mymicds-blur--dark class="sidebar" [class.sidebar-collapsed]="sidebarCollapsed">
 				<div class="sidebar-header" [style.text-align]="selectionDate === null ? 'left' : 'inherit'">
-					<h1>
+					<h2>
 						<span *ngIf="selectionDate === null">Coming Up</span>
-					</h1>
+					</h2>
 						<span *ngIf="selectionDate !== null" class="date-display">{{ selectionDate.toDate() | momentDate:'MMMM d, y':'America/Chicago' }}</span>
 
 					<h3 *ngIf="selectionDate !== null && days[selectionDate.year()] && days[selectionDate.year()][selectionDate.month() + 1] && days[selectionDate.year()][selectionDate.month() + 1][selectionDate.date()]">

--- a/src/app/components/planner/planner.component.scss
+++ b/src/app/components/planner/planner.component.scss
@@ -386,8 +386,6 @@
 				}
 
 				.coming-up {
-					top: 6em;
-
 					.coming-up-day {
 
 						.coming-up-due {
@@ -451,7 +449,26 @@
 	}
 }
 
-@media screen and (min-width:544px) {
+@media only screen and (min-width:240px) {
+	.planner-interface {
+		.planner-container {
+			.calendar-container {
+				.sidebar {
+
+					.coming-up {
+						top: 10.5rem;
+					}
+
+					.day-selection {
+						top: 14.5rem;
+					}
+				}
+			}
+		}
+	}
+}
+
+@media only screen and (min-width:544px) {
 	.planner-interface {
 		// Add padding instead of margin so clicking the bottom will also deselect the day
 		padding: 2rem 0 6rem 0;
@@ -537,6 +554,15 @@
 							}
 						}
 					}
+
+					.coming-up {
+						top: 7.5rem;
+					}
+
+					.day-selection {
+						top: 13rem;
+					}
+
 				}
 			}
 		}
@@ -645,29 +671,7 @@
 					}
 
 					.day-selection {
-						top: 14.5rem;
-					}
-				}
-			}
-		}
-	}
-}
-
-
-@media screen and (min-width:250px) and (max-width:543px) {
-	.planner-interface {
-		.planner-container {
-			.calendar-container {
-				.sidebar {
-
-					margin-left: inherit;
-
-					.coming-up {
-						top: 9.5em;
-					}
-
-					.day-selection{
-						top: 15.5em;
+						top: 14rem;
 					}
 				}
 			}

--- a/src/app/components/planner/planner.component.scss
+++ b/src/app/components/planner/planner.component.scss
@@ -273,7 +273,7 @@
 					.sidebar-buttons {
 						display: flex;
 						flex-direction: column;
-						margin: 1rem auto 0.5rem;
+						margin: 0.5rem auto 0.5rem;
 
 						.sidebar-coming-up {
 							margin-bottom: 0.5rem;
@@ -641,11 +641,33 @@
 					}
 
 					.coming-up {
-						top: 8rem;
+						top: 8.5rem;
 					}
 
 					.day-selection {
-						top: 14rem;
+						top: 14.5rem;
+					}
+				}
+			}
+		}
+	}
+}
+
+
+@media screen and (min-width:250px) and (max-width:543px) {
+	.planner-interface {
+		.planner-container {
+			.calendar-container {
+				.sidebar {
+
+					margin-left: inherit;
+
+					.coming-up {
+						top: 9.5em;
+					}
+
+					.day-selection{
+						top: 15em;
 					}
 				}
 			}

--- a/src/app/components/planner/planner.component.scss
+++ b/src/app/components/planner/planner.component.scss
@@ -667,7 +667,7 @@
 					}
 
 					.day-selection{
-						top: 15em;
+						top: 15.5em;
 					}
 				}
 			}

--- a/src/app/components/planner/planner.component.scss
+++ b/src/app/components/planner/planner.component.scss
@@ -456,11 +456,11 @@
 				.sidebar {
 
 					.coming-up {
-						top: 10.5rem;
+						top: 10rem;
 					}
 
 					.day-selection {
-						top: 14.5rem;
+						top: 14.25rem;
 					}
 				}
 			}
@@ -667,7 +667,7 @@
 					}
 
 					.coming-up {
-						top: 8.5rem;
+						top: 7.3rem;
 					}
 
 					.day-selection {

--- a/src/app/components/planner/planner.component.scss
+++ b/src/app/components/planner/planner.component.scss
@@ -456,11 +456,11 @@
 				.sidebar {
 
 					.coming-up {
-						top: 10rem;
+						top: 8rem;
 					}
 
 					.day-selection {
-						top: 14.25rem;
+						top: 13rem;
 					}
 				}
 			}


### PR DESCRIPTION
Hopefully, this fixes the issue for now. Researching this bug revealed a flaw within how the entire page was setup. In the future, we'd need to change the container `flex-direction` to `column` (right now its `row`). 

This would require a significant rework, but allow the use of relative positioning, and less headaches in the future. 

Another issue will be opened. For now, this should work. 