### PR TITLE
Hotfix

### DIFF
--- a/src/app/components/daily-bulletin/daily-bulletin.component.html
+++ b/src/app/components/daily-bulletin/daily-bulletin.component.html
@@ -5,7 +5,7 @@
 		<div class="bulletin-navigation">
 			<button mymicds-blur class="previous-bulletin" routerLink="/daily-bulletin" (click)="previousBulletin()" [disabled]="bulletinIndex === bulletins.length - 1">
 				<span>
-					<fa-icon [icon]="['fas','angle-left']"></fa-icon>
+					<fa-icon icon="angle-left"></fa-icon>
 					Previous
 				</span>
 			</button>
@@ -18,7 +18,7 @@
 			<button mymicds-blur class="next-bulletin" routerLink="/daily-bulletin" (click)="nextBulletin()" [disabled]="bulletinIndex === 0">
 				<span>
 					Next
-				 <fa-icon [icon]="['fas','angle-right']"></fa-icon>
+				 <fa-icon icon="angle-right"></fa-icon>
 				</span>
 			</button>
 		</div>

--- a/src/app/components/forgot-password/forgot-password.component.html
+++ b/src/app/components/forgot-password/forgot-password.component.html
@@ -24,13 +24,13 @@
 	<div mymicds-blur *ngIf="submitted && forgotResponse === true" class="forgot-response">
 		<h1>Password Reset Email Sent!</h1>
 		<p>Please wait a few minutes for the email to come through. If it isn't in your inbox, check your spam.</p>
-		<fa-icon [icon]="check" size="5x"></fa-icon>
+		<fa-icon icon="check" size="5x"></fa-icon>
 		<a class="gmail btn btn-info btn-lg" href="https://mail.google.com">Click here to go to Gmail</a>
 	</div>
 	<!-- Failure Response -->
 	<div mymicds-blur *ngIf="submitted && typeOf(forgotResponse) === 'string'" class="forgot-response">
 		<h1>{{forgotResponse}}</h1>
-		<fa-icon [icon]="times" size="5x"></fa-icon>
+		<fa-icon icon="times" size="5x"></fa-icon>
 		<p><a (click)="resubmitForm()">Try again</a> or contact support if an unexpected error keeps happening.</p>
 	</div>
 </div>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -18,7 +18,7 @@
 		<button class="btn btn-danger" (click)="saveModules([])" [disabled]="!mymicds.auth.isLoggedIn">Reset Layout</button>
 	</div>
 	<p mymicds-blur--dark class="manage-help">
-		<fa-icon [icon]="['fas','info-circle']"></fa-icon>
+		<fa-icon icon="info-circle"></fa-icon>
 		Drag, drop, and resize modules on the grid to your liking!
 	</p>
 </div>
@@ -63,7 +63,7 @@
 						container="body"
 						placement="bottom">
 
-						<fa-icon [icon]="cog"></fa-icon>
+						<fa-icon icon="cog"></fa-icon>
 						Configure
 					</button>
 					<div class="edit-module-resize">

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -2,7 +2,7 @@
 	<div class="manage-menu">
 		<div class="manage-buttons">
 			<a mymicds-blur class="edit" routerLink="/home/edit">
-				<fa-icon [icon]="edit"></fa-icon>
+				<fa-icon icon="edit"></fa-icon>
 				Edit
 			</a>
 		</div>

--- a/src/app/components/module-inspector/module-inspector.component.html
+++ b/src/app/components/module-inspector/module-inspector.component.html
@@ -30,14 +30,14 @@
 
 <div *ngIf="fixedHeight" class="fixed-height module-container-container" [style.width]="moduleWidth + 'px'" [style.height]="moduleHeight + 'px'">
 	<div class="resize-icon">
-		<fa-icon [icon]="expand" flip="horizontal"></fa-icon>
+		<fa-icon icon="expand" flip="horizontal"></fa-icon>
 	</div>
 	<mymicds-module-container [type]="selectedModuleType" [inputs]="moduleOptions" [fixedHeight]="true"></mymicds-module-container>
 </div>
 
 <div *ngIf="!fixedHeight" class="module-container-container" [style.width]="moduleWidth + 'px'">
 	<div class="resize-icon">
-		<fa-icon [icon]="expand" flip="horizontal"></fa-icon>
+		<fa-icon icon="expand" flip="horizontal"></fa-icon>
 	</div>
 	<mymicds-module-container [type]="selectedModuleType" [inputs]="moduleOptions" [fixedHeight]="false"></mymicds-module-container>
 </div>

--- a/src/app/components/module-options/module-option/module-option.component.html
+++ b/src/app/components/module-options/module-option/module-option.component.html
@@ -22,7 +22,7 @@
 			<input class="form-control" [(ngModel)]="value">
 			<span class="input-group-btn">
 				<button class="btn btn-secondary" (click)="onTogglePicker()">
-					<fa-icon [icon]="calendar"></fa-icon>
+					<fa-icon icon="calendar"></fa-icon>
 				</button>
 			</span>
 		</div>

--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -7,13 +7,13 @@
 	<div mymicds-blur *ngIf="submitted && registerResponse === true" class="register-response">
 		<h1>Confirmation Email Sent!</h1>
 		<p>Please wait a few minutes for the email to come through. If it isn't in your inbox, check your spam.</p>
-		<fa-icon [icon]="check" size="5x"></fa-icon>
+		<fa-icon icon="check" size="5x"></fa-icon>
 		<a class="gmail btn btn-lg btn-block btn-info" href="https://mail.google.com">Take me to Gmail</a>
 	</div>
 	<!-- Failure Response -->
 	<div mymicds-blur *ngIf="submitted && typeOf(registerResponse) === 'string'" class="register-response">
 		<h1>{{registerResponse}}</h1>
-		<fa-icon [icon]="times" size="5x"></fa-icon>
+		<fa-icon icon="times" size="5x"></fa-icon>
 		<p><a (click)="resubmitForm()">Try again</a> or contact support if an unexpected error keeps happening.</p>
 	</div>
 </div>

--- a/src/app/components/reset-password/reset-password.component.html
+++ b/src/app/components/reset-password/reset-password.component.html
@@ -20,13 +20,13 @@
 	<!-- Success Response -->
 	<div mymicds-blur *ngIf="submitted && resetResponse === true" class="reset-response">
 		<h1>Password Changed!</h1>
-		<fa-icon [icon]="check" size="5x"></fa-icon>
+		<fa-icon icon="check" size="5x"></fa-icon>
 		<button routerLink="/login" class="btn btn-lg btn-block btn-success">Login</button>
 	</div>
 	<!-- Failure Response -->
 	<div mymicds-blur *ngIf="submitted && typeOf(resetResponse) === 'string'" class="reset-response">
 		<h1>There was an error resetting your password!</h1>
-		<fa-icon [icon]="times" size="5x"></fa-icon>
+		<fa-icon icon="times" size="5x"></fa-icon>
 		<p>Make sure you click the link on the most recent email you recieved. Contact support if an unexpected error keeps happening.</p>
 	</div>
 </div>

--- a/src/app/components/settings/classes/classes.component.html
+++ b/src/app/components/settings/classes/classes.component.html
@@ -42,16 +42,16 @@
 						(click)="aliasClass = class; aliasModal.show()"
 						[disabled]="savingClasses || !class._id"
 						tooltip="Save the class before linking it!">
-						<fa-icon [icon]="link"></fa-icon>
+						<fa-icon icon="link"></fa-icon>
 						Link
 					</button>
 				</div>
 				<button class="btn btn-warning" (click)="restoreClass(class._id)" [disabled]="savingClasses || !classChanged(class._id) || !class._id">
-					<fa-icon [icon]="undo"></fa-icon>
+					<fa-icon icon="undo"></fa-icon>
 					Restore
 				</button>
 				<button class="btn btn-danger" (click)="deleteClass(i)" [disabled]="savingClasses">
-					<fa-icon [icon]="times"></fa-icon>
+					<fa-icon icon="times"></fa-icon>
 					Delete
 				</button>
 			</td>

--- a/src/app/components/suggestions/suggestions.component.html
+++ b/src/app/components/suggestions/suggestions.component.html
@@ -25,13 +25,13 @@
 	<div mymicds-blur *ngIf="submitted && suggestionResponse === true" class="suggestions-response">
 		<h1>Success!</h1>
 		<p>The MyMICDS Development Team is working on it. We'll try to send you a follow-up email.</p>
-		<fa-icon [icon]="check" size="5x"></fa-icon>
+		<fa-icon icon="check" size="5x"></fa-icon>
 		<p>Thanks for helping improve the site!</p>
 	</div>
 	<!-- Failure Response -->
 	<div mymicds-blur *ngIf="submitted && typeOf(suggestionResponse) === 'string'" class="suggestions-response">
 		<h1>{{suggestionResponse}}</h1>
-		<fa-icon [icon]="times" size="5x"></fa-icon>
+		<fa-icon icon="times" size="5x"></fa-icon>
 		<p><a (click)="resubmitForm()">Try again</a> or contact support if an unexpected error keeps happening.</p>
 	</div>
 </div>

--- a/src/app/components/unsubscribe/unsubscribe.component.html
+++ b/src/app/components/unsubscribe/unsubscribe.component.html
@@ -4,12 +4,12 @@
 	</div>
 	<div mymicds-blur *ngIf="unsubscribeResponse === true" class="unsubscribe-response">
 		<h1>Sorry to bother you!</h1>
-		<fa-icon [icon]="check" size="5x"></fa-icon>
+		<fa-icon icon="check" size="5x"></fa-icon>
 		<p class="unsubscribe-success">You will no longer receive these types of emails.</p>
 	</div>
 	<div mymicds-blur *ngIf="unsubscribeResponse === false" class="unsubscribe-response">
 		<h1>Uh oh.</h1>
-		<fa-icon [icon]="times" size="5x"></fa-icon>
+		<fa-icon icon="times" size="5x"></fa-icon>
 		<p>There was an error unsubscribing. Try clicking the unsubscribe link again. Contact support if this keeps happening.</p>
 	</div>
 </div>


### PR DESCRIPTION
turns out when you use the `<fa-icon>` tag in this syntax: `[icon]='name'`, it breaks, and you must remove the brackets. 