### PR TITLE
Use ngValue binding, fix register

### DIFF
--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -62,7 +62,7 @@
 			<div *ngIf="!registerForm?.controls?.teacher.value" class="student">
 				<div class="form-element">Choose your graduation year</div>
 				<select class="form-control" formControlName="gradYear">
-					<option *ngFor="let year of gradeRange; let grade = index" [value]="year">Class of {{ year }} ({{ 12 - grade | gradePipe }})</option>
+					<option *ngFor="let year of gradeRange; let grade = index" [ngValue]="year">Class of {{ year }} ({{ 12 - grade | gradePipe }})</option>
 				</select>
 			</div>
 		</fieldset>


### PR DESCRIPTION
This PR fixes a bug I noticed on production where `gradYear` values were being sent to the backend as strings instead of numbers, causing the parameter schema to throw validation errors.