### PR TITLE
Enforce alphabetical usernames

### DIFF
--- a/src/app/authentication/register/register.component.html
+++ b/src/app/authentication/register/register.component.html
@@ -32,7 +32,9 @@
 					<div class="input-group-text">@micds.org</div>
 				</div>
 			</div>
-			<p class="form-text" [class.text-warning]="!isAlphabetic(registerForm.controls.user.value)">Your username is the prefix of your MICDS email. This typically <strong>does not</strong> contain numbers or weird symbols.</p>
+			<p class="form-text" [class.text-danger]="registerForm.controls.user.dirty && registerForm.controls.user.invalid">
+				Your username is the prefix of your MICDS email. This typically <strong>does not</strong> contain numbers or weird symbols.
+			</p>
 		</fieldset>
 		<fieldset class="form-group">
 			<legend>Password</legend>

--- a/src/app/authentication/register/register.component.ts
+++ b/src/app/authentication/register/register.component.ts
@@ -16,11 +16,10 @@ import { SubscriptionsComponent } from '../../common/subscriptions-component';
 export class RegisterComponent extends SubscriptionsComponent implements OnInit {
 
 	// We need to include this to use in HTML
-	public isAlphabetic = isAlphabetic; // tslint:disable-line
 	public typeOf = typeOf; // tslint:disable-line
 
 	registerForm = this.formBuilder.group({
-		user: ['', Validators.required],
+		user: ['', [Validators.required, Validators.pattern(/^[a-z-]+$/)]],
 		password: ['', Validators.required],
 		confirmPassword: ['', Validators.required],
 		firstName: ['', Validators.required],


### PR DESCRIPTION
Resolves #151. Works with hyphenated usernames as well as purely alphabetic ones.