### PR TITLE
Add Sentry integration, change deploy strategy

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -9,24 +9,14 @@ mkdir -p ~/.ssh
 ssh-keyscan -p $PORT $IP >> ~/.ssh/known_hosts
 
 ssh apps@$IP -p $PORT <<EOF
-  cd $DEPLOY_DIR
-  git pull
-  npm ci
-  ng build --prod
-
   # Make backup of current production stuff
   TIMESTAMP=\$(date --rfc-3339=seconds)
   mkdir /home/apps/MyMICDS/production-backups/"\$TIMESTAMP"
   cp -R /var/www/mymicds/mymicds-angular/* /home/apps/MyMICDS/production-backups/"\$TIMESTAMP"
 
-  BUILD_DIR=$DEPLOY_DIR/dist/mymicds-v2-angular
-  # Check for a successful build
-  if [ ! -d "\$BUILD_DIR" ]; then
-    echo "Build failed, exiting"
-    exit 1
-  fi
-
-  # Copy new compiled files into production
+  # Remove old build
   rm -rf /var/www/mymicds/mymicds-angular/*
-  cp -R \$BUILD_DIR/* /var/www/mymicds/mymicds-angular
 EOF
+
+# copy over new build
+scp -P $PORT build/* apps@$IP:/var/www/mymicds/mymicds-angular

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -19,4 +19,4 @@ ssh apps@$IP -p $PORT <<EOF
 EOF
 
 # copy over new build
-scp -P $PORT build/* apps@$IP:/var/www/mymicds/mymicds-angular
+scp -r -P $PORT build/* apps@$IP:/var/www/mymicds/mymicds-angular

--- a/.github/secrets/_config.prod.scss
+++ b/.github/secrets/_config.prod.scss
@@ -1,0 +1,9 @@
+/**
+ * PLEASE copypasterino the contents of this file into a _config.scss with the information properly filled out.
+ * PLEASE make a _config.scss for every machine you to develop on.
+ * DO NOT get rid of this example file.
+ * Any _config.example.scss is under the .gitignore so we can change parameters depending on the dev environment.
+ */
+
+// Backend URL
+$backend-url: 'https://api.mymicds.net/v3';

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,9 +1,9 @@
-name: MyMICDS CI
+name: Production
 
 on:
   push:
-    branches: master
-  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14 # Current LTS
       - name: Install dependencies
         run: npm ci
       - name: Create configs
@@ -35,10 +35,6 @@ jobs:
             !dist/mymicds-v2-angular/*.map
 
   deploy:
-    # even though the workflow should only run if we're on master in the first place,
-    # explicitly check before running the deploy in case we broaden the workflow events
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-
     runs-on: ubuntu-latest
     needs: build
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,20 @@
+name: Pull request
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14 # Current LTS
+      - name: Install dependencies
+        run: npm ci
+      - name: Create configs
+        run: cp src/styles/_config.example.scss src/styles/_config.scss
+      - name: Build in production mode
+        run: npm run build:prod

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,9 +18,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Create configs
-        run: cp src/styles/_config.example.scss src/styles/_config.scss
+        run: cp .github/secrets/_config.prod.scss src/styles/_config.scss
       - name: Build in production mode
         run: npm run build:prod
+      - name: Save maps
+        uses: actions/upload-artifact@v2
+        with:
+          name: maps
+          path: dist/mymicds-v2-angular/*.map
+      - name: Save production build
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: |
+            dist/mymicds-v2-angular
+            !dist/mymicds-v2-angular/*.map
 
   deploy:
     # even though the workflow should only run if we're on master in the first place,
@@ -37,12 +49,13 @@ jobs:
         env:
           FILE_DECRYPT_KEY: ${{ secrets.FILE_DECRYPT_KEY }}
           FILE_DECRYPT_IV: ${{ secrets.FILE_DECRYPT_IV }}
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
       - name: Deploy to remote server
         run: ./.github/scripts/deploy.sh
         env:
           IP: ${{ secrets.DEPLOY_SSH_IP }}
           PORT: ${{ secrets.DEPLOY_SSH_PORT }}
-          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -51,3 +64,4 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           environment: production
+          sourcemaps: maps

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,3 +43,11 @@ jobs:
           IP: ${{ secrets.DEPLOY_SSH_IP }}
           PORT: ${{ secrets.DEPLOY_SSH_PORT }}
           DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production

--- a/angular.json
+++ b/angular.json
@@ -52,7 +52,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "aot": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,6 +1979,97 @@
         }
       }
     },
+    "@sentry/angular": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-5.29.0.tgz",
+      "integrity": "sha512-PzoJRRmaPNTL10eFY9BFUWNe6eusdxxyP/OPR1vbfQQCniN7YP8bHIF7glfxFkRE/+J7wlfxTA2HaPafMYg7qQ==",
+      "requires": {
+        "@sentry/browser": "5.29.0",
+        "@sentry/types": "5.29.0",
+        "@sentry/utils": "5.29.0",
+        "rxjs": "^6.6.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
+      }
+    },
+    "@sentry/browser": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.29.0.tgz",
+      "integrity": "sha512-kRlt1mE2wrYjspnIupNnPxqsUrRuy02SuXhbpP7J6uu8QasoEmJ78hk0hHz4jOZRmuWwfs2zIXD4tLGgWOKq8A==",
+      "requires": {
+        "@sentry/core": "5.29.0",
+        "@sentry/types": "5.29.0",
+        "@sentry/utils": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.29.0.tgz",
+      "integrity": "sha512-a1sZBJ2u3NG0YDlGvOTwUCWiNjhfmDtAQiKK1o6RIIbcrWy9TlSps7CYDkBP239Y3A4pnvohjEEKEP3v3L3LZQ==",
+      "requires": {
+        "@sentry/hub": "5.29.0",
+        "@sentry/minimal": "5.29.0",
+        "@sentry/types": "5.29.0",
+        "@sentry/utils": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.29.0.tgz",
+      "integrity": "sha512-kcDPQsRG4cFdmqDh+TzjeO7lWYxU8s1dZYAbbl1J4uGKmhNB0J7I4ak4SGwTsXLY6fhbierxr6PRaoNojCxjPw==",
+      "requires": {
+        "@sentry/types": "5.29.0",
+        "@sentry/utils": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.29.0.tgz",
+      "integrity": "sha512-nhXofdjtO41/caiF1wk1oT3p/QuhOZDYdF/b29DoD2MiAMK9IjhhOXI/gqaRpDKkXlDvd95fDTcx4t/MqqcKXA==",
+      "requires": {
+        "@sentry/hub": "5.29.0",
+        "@sentry/types": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.29.0.tgz",
+      "integrity": "sha512-2ZITUH7Eur7IkmRAd5gw8Xt2Sfc28btCnT7o2P2J8ZPD65e99ATqjxXPokx0+6zEkTsstIDD3mbyuwkpbuvuTA==",
+      "requires": {
+        "@sentry/hub": "5.29.0",
+        "@sentry/minimal": "5.29.0",
+        "@sentry/types": "5.29.0",
+        "@sentry/utils": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.29.0.tgz",
+      "integrity": "sha512-iDkxT/9sT3UF+Xb+JyLjZ5caMXsgLfRyV9VXQEiR2J6mgpMielj184d9jeF3bm/VMuAf/VFFqrHlcVsVgmrrMw=="
+    },
+    "@sentry/utils": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.29.0.tgz",
+      "integrity": "sha512-b2B1gshw2u3EHlAi84PuI5sfmLKXW1z9enMMhNuuNT/CoRp+g5kMAcUv/qYTws7UNnYSvTuVGuZG30v1e0hP9A==",
+      "requires": {
+        "@sentry/types": "5.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@fortawesome/free-regular-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@mymicds/sdk": "^1.11.0",
+    "@sentry/angular": "^5.29.0",
+    "@sentry/tracing": "^5.29.0",
     "angular-fittext": "^2.1.1",
     "angular2gridster": "^8.1.0",
     "animate.css": "^3.6.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { MyMICDS } from '@mymicds/sdk';
 import { MyMICDSFactory } from './common/mymicds-sdk';
 
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
 import { appRoutingProviders, routing } from './app.routing';
 import { ColorPickerModule } from 'ngx-color-picker';
@@ -19,6 +20,8 @@ import { FontAwesomeModule, FaIconLibrary } from '@fortawesome/angular-fontaweso
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
 import { fab } from '@fortawesome/free-brands-svg-icons';
+
+import * as Sentry from '@sentry/angular';
 
 import { AppComponent } from './app.component';
 import { AlertComponent } from './components/alert/alert.component';
@@ -85,8 +88,25 @@ import { AuthenticationModule } from './authentication/authentication.module';
 		appRoutingProviders,
 		Title,
 		AlertService,
-		BackgroundService
+		BackgroundService,
 		// RealtimeService,
+		// Sentry stuff for better traces
+		{
+			provide: ErrorHandler,
+			useValue: Sentry.createErrorHandler({
+				showDialog: true,
+			}),
+		},
+		{
+			provide: Sentry.TraceService,
+			deps: [Router],
+		},
+		{
+			provide: APP_INITIALIZER,
+			useFactory: () => () => {},
+			deps: [Sentry.TraceService],
+			multi: true,
+		},
 	],
 	bootstrap: [AppComponent],
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,20 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 import { AppModule } from './app/app.module';
+import * as Sentry from '@sentry/angular';
+import { Integrations } from '@sentry/tracing';
+
+Sentry.init({
+	dsn: 'https://5b482947b3f44153a674e6f676d9cdf8@o355493.ingest.sentry.io/5551465',
+	autoSessionTracking: true,
+	integrations: [
+		new Integrations.BrowserTracing({
+			tracingOrigins: ['localhost', 'https://mymicds.net'],
+			routingInstrumentation: Sentry.routingInstrumentation,
+		}),
+	],
+	tracesSampleRate: 1.0,
+});
 
 if (environment.production) {
 	enableProdMode();


### PR DESCRIPTION
This PR adds full Sentry integration with the frontend, including uploading sourcemaps for stack traces.

Additionally, instead of rebuilding the frontend on the production server and deploying there, this PR changes our deploy flow to use GitHub Actions artifacts and upload the build from the `test` job. (This was the easiest way to get production sourcemaps onto Sentry.)

Resolves #114.