### PR TITLE
Update app.module.ts

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -70,7 +70,7 @@ import { SharedModule } from './shared/shared.module';
 		{
 			provide: ErrorHandler,
 			useValue: Sentry.createErrorHandler({
-				showDialog: true
+				showDialog: false
 			})
 		},
 		{


### PR DESCRIPTION
This stops the Sentry Crash report from appearing to the user. It will still be on the sentry dashboard on our end, but this will stop the user from being annoyed by any error becoming a crash.