### PR TITLE
Add forms module to password reset page

### DIFF
--- a/src/app/reset-password/reset-password.module.ts
+++ b/src/app/reset-password/reset-password.module.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { ResetPasswordComponent } from './reset-password/reset-password.component';
@@ -8,6 +9,12 @@ import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
 	declarations: [ResetPasswordComponent],
-	imports: [CommonModule, ResetPasswordRoutingModule, SharedModule]
+	imports: [
+		CommonModule,
+		ResetPasswordRoutingModule,
+		SharedModule,
+		FormsModule,
+		ReactiveFormsModule
+	]
 })
 export class ResetPasswordModule {}


### PR DESCRIPTION
Before, the password reset page would not let the user submit the form even if it was valid. This was because the Angular Forms module was missing from the reset password module.