### PR TITLE
Fix JK/SK year-to-grade conversion

### DIFF
--- a/src/app/shared/pipes/grade-pipe.pipe.ts
+++ b/src/app/shared/pipes/grade-pipe.pipe.ts
@@ -8,9 +8,9 @@ export class GradePipePipe implements PipeTransform {
 	transform(value: number) {
 		switch (value) {
 			case -1:
-				return 'SK';
-			case 0:
 				return 'JK';
+			case 0:
+				return 'SK';
 			default:
 				return `${value}${ordinalSuffix(value)} Grade`;
 		}


### PR DESCRIPTION
This PR fixes the grade dropdown in the registration page/settings. Right now, the dropdown ordering of the grades is SK, JK, 1st grade, etc...

However, this is incorrect because JK (Junior Kindergarten) comes before SK (Senior Kindergarten).